### PR TITLE
BREAKING CHANGE:Streamline to align better with jwk api.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/lestrrat-go/jwx/v2 v2.1.3
 	github.com/stretchr/testify v1.10.0
 	github.com/tinylib/msgp v1.2.5
-	github.com/xmidt-org/jwskeychain v1.1.0
+	github.com/xmidt-org/jwskeychain v1.2.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -30,12 +30,10 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tinylib/msgp v1.2.5 h1:WeQg1whrXRFiZusidTQqzETkRpGjFjcIhW6uqWH09po=
 github.com/tinylib/msgp v1.2.5/go.mod h1:ykjzy2wzgrlvpDCRc4LA8UXy6D8bzMSuAF3WD57Gok0=
-github.com/xmidt-org/jwskeychain v1.1.0 h1:WhC6AcVMcy5IuLWbcYp//GGRPDmOpXmLQS02NPNdUwc=
-github.com/xmidt-org/jwskeychain v1.1.0/go.mod h1:aDQ9lGHwJYxCubgeJGXQQXGFkL3ZZStvfEHFEh4MO+Y=
+github.com/xmidt-org/jwskeychain v1.2.0 h1:5lLSNon/6po9ObuJTNAwHzQU8D9HIjknRHgLxMmyUWU=
+github.com/xmidt-org/jwskeychain v1.2.0/go.mod h1:aDQ9lGHwJYxCubgeJGXQQXGFkL3ZZStvfEHFEh4MO+Y=
 golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
 golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
-golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
-golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/securly.go
+++ b/securly.go
@@ -130,12 +130,12 @@ func (m Message) Encode() (data []byte, isEncrypted bool, err error) {
 // Sign converts a Message into a slice of bytes and signs it using the
 // provided options.
 func (m Message) Sign(opts ...SignOption) ([]byte, error) {
-	enc, err := newEncoder(opts...)
+	enc, err := NewSigner(opts...)
 	if err != nil {
 		return nil, err
 	}
 
-	return enc.encode(m)
+	return enc.Encode(m)
 }
 
 // Encrypt encrypts the message using the provided options.


### PR DESCRIPTION
BREAKING CHANGE!

A few of the options go away in favor of leaning on the jws/jwk library and jwskeychain to provide more of that verification.

Removed:
- RequirePolicies
- Require
- TrustRootCAs
- Verifier
- SignWith
- SignWithRaw

Added:
- Signer
- NewSigner
- SignWithX509Chain
- SignWithKey
- Decoder
- NewDecoder
- WithKeyProvider
- WithKeySet
- WithKeyUsed
- WithVerifyAuto

This was done to incorporate the flexability available from the jws/jwk libraries but limit some of the things that could be configured that would break this library.